### PR TITLE
Centralise media file extension constants

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -21,6 +21,8 @@ from typing import Dict, Tuple, List, Optional
 
 import streamlit as st
 
+from core.constants import AUDIO_EXTS, VIDEO_EXTS
+
 # ------------------------------ page config ----------------------------------
 
 st.set_page_config(
@@ -42,8 +44,6 @@ COMBINED_FIXED = OUTPUTS_DIR / "combined_transcript.txt"  # not used by core, we
 SUMMARY_FIXED = OUTPUTS_DIR / "summary.txt"
 ACTIONS_FIXED = OUTPUTS_DIR / "action_items.txt"
 
-VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".flv", ".webm"}
-AUDIO_EXTS = {".wav", ".mp3", ".aac", ".ogg", ".flac", ".m4a", ".wma", ".ogg"}
 MAX_PREVIEW_MB = 75
 
 # Allow-list a few OCR language tags (extend if you enable EasyOCR langs)

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,0 +1,20 @@
+"""Shared constants for media file handling."""
+
+VIDEO_EXTS = {
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".avi",
+    ".flv",
+    ".webm",
+}
+
+AUDIO_EXTS = {
+    ".wav",
+    ".mp3",
+    ".aac",
+    ".ogg",
+    ".flac",
+    ".m4a",
+    ".wma",
+}

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -14,14 +14,19 @@ import sys
 import time
 from pathlib import Path
 
+# Ensure repository root is importable when executed as a script (python core/pipeline.py)
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from core.constants import VIDEO_EXTS
+
 # Canonical output paths (match the app)
 TRANSCRIPT = "outputs/transcript.txt"
 SLIDES     = "outputs/slide_texts.txt"
 COMBINED   = "outputs/combined_transcript.txt"
 SUMMARY    = "outputs/summary.txt"
 ACTIONS    = "outputs/action_items.txt"
-
-VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".flv", ".webm"}
 
 def is_video(path: str) -> bool:
     return Path(path).suffix.lower() in VIDEO_EXTS

--- a/core/transcribe.py
+++ b/core/transcribe.py
@@ -17,8 +17,16 @@ import os
 import subprocess
 import torch
 import shutil
+from pathlib import Path
 from faster_whisper import WhisperModel
 from imageio_ffmpeg import get_ffmpeg_exe  # portable ffmpeg locator
+
+# Ensure repository root is importable when executed as a script (python core/transcribe.py)
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from core.constants import AUDIO_EXTS, VIDEO_EXTS
 
 # -------------------------- helpers: file type detection -------------------------- #
 
@@ -26,15 +34,13 @@ def is_video_file(filepath):
     """
     Returns True if the file extension matches a known video format.
     """
-    video_exts = {'.mp4', '.mov', '.avi', '.mkv', '.flv', '.webm'}
-    return os.path.splitext(filepath)[1].lower() in video_exts
+    return os.path.splitext(filepath)[1].lower() in VIDEO_EXTS
 
 def is_audio_file(filepath):
     """
     Returns True if the file extension matches a known audio format.
     """
-    audio_exts = {'.wav', '.mp3', '.aac', '.ogg', '.flac', '.m4a', '.wma'}
-    return os.path.splitext(filepath)[1].lower() in audio_exts
+    return os.path.splitext(filepath)[1].lower() in AUDIO_EXTS
 
 # ------------------------------ ffmpeg audio extract ------------------------------ #
 


### PR DESCRIPTION
## Summary
- add `core/constants.py` to share the canonical audio and video extension lists
- import the shared constants in the Streamlit app and core CLI scripts while keeping script execution compatible with absolute imports

## Testing
- python -m compileall app core

------
https://chatgpt.com/codex/tasks/task_e_68c97fd4136c832997cac4f0221eaf76